### PR TITLE
Fix branch build

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,12 +1,27 @@
 #!/bin/sh
 set -ex
+apt update -y
+DEBIAN_FRONTEND=noninteractive apt install -y php-cli zip unzip
 hhvm --version
+php --version
+if [ ! -e .git/refs/heads/master ]; then
+  # - Travis clones with `--branch`, then moves to a detached HEAD state
+  # - if we're on a detached HEAD, Composer uses master to resolve branch
+  #   aliases.
+  # So, create the master branch :p
+  git branch master HEAD
+fi
 
-composer install
+(
+  cd $(mktemp -d)
+  curl https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+)
+if (hhvm --version | grep -q -- -dev); then
+  # Doesn't exist in master, but keep it here so that we can test release
+  # branches on nightlies too
+  rm -f composer.lock
+fi
+hhvm /usr/local/bin/composer install
 
 hh_client
-
 vendor/bin/hacktest tests/
-
-echo > .hhconfig
-hh_server --check $(pwd)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
-language: php
-php:
- - hhvm-3.30
- 
+sudo: required
+language: generic
+services: docker
+env:
+- HHVM_VERSION=3.30.12
+install:
+- docker pull hhvm/hhvm:$HHVM_VERSION
 script:
- - ./.travis.sh
+- docker run --rm -w /var/source -v $(pwd):/var/source hhvm/hhvm:$HHVM_VERSION ./.travis.sh
 notifications:
   webhooks: https://code.facebook.com/travis/webhook/
+  slack:
+    secure: LH2n9tQoW3/OUO/ppXLnGIVAbYtl07avQne/gkcal/csGc18BSly15/bNZvGTlC65aac+yjbGHlcWuBm8Qyl5l2oWZADqoRN7+HeOYw1qSx2eRA5BzVcdKd9eHjl5xobxLC2NXZL/NSiN+Ku/YDuzzkwpGqIcC4EiwvFsab6B2rigdazFaNRceAxnyYwNs3VdzFj9vBDqbfUDFV7lgjZJxbKos26O/Z4F58a2tsV2hbT+tF8W3hfPrMaYuxWVv2+Irc0uGoNc5EG+2eRT5AzMtp6YKzQ5LzEkC/lNwojUg/dr9xV+3vZu+IARy7HsBuX5KZo3IBGHL18q8srgEM4NBQy8IUmVAlGGw7vw1cInIoqUTOvHBqVvDAs2RNr5f7u+2Li0Sw9vuGhoeNtLVvTjZ9r5XmEzdEx9pUFrsO16YdJLnpiYiyWlWAeAkDljXD/d5L/i0sZgaeY/eubYADJr/ZA+M78aiLuw5eEWqu5s9a4xhrGEBkUHyPRpXU1AxVAPr1L6/PK47QKYu1h45QfMQL8TmrNw9VPLUIm5P4k3RFz9CC5C35u5HfFTubErcDl1CZUSoGUuW4foTbkWSJGlgvQquS824mL2VIO5Ut6J6+/2iqsK/HfKOiToDpiiwpe2KoQsyy5QHVWMVNTuKPou1yYH+6Z3DIx8/wEAkvCA+U=


### PR DESCRIPTION
### What has been done
- Use the `hhvm/hhvm:3.30.12` image for running `.travis.sh` for consistent builds. Code is mostly copied over from the `v3.29.x` branch.
- Motivation:
  - [Succeeding PR build.](https://travis-ci.org/hhvm/hsl/builds/648634784)
  - [Failing branch build.](https://travis-ci.org/hhvm/hsl/builds/648639054)